### PR TITLE
[fix] Use static callback for array_map

### DIFF
--- a/link
+++ b/link
@@ -42,7 +42,7 @@ $sfPackages = array('symfony/symfony' => __DIR__);
 
 $filesystem = new Filesystem();
 $braces = array('Bundle', 'Bridge', 'Component', 'Component/Security', 'Component/Mailer/Bridge', 'Component/Messenger/Bridge', 'Component/Notifier/Bridge', 'Contracts', 'Component/Translation/Bridge');
-$directories = array_merge(...array_values(array_map(function ($part) {
+$directories = array_merge(...array_values(array_map(static function ($part) {
     return glob(__DIR__.'/src/Symfony/'.$part.'/*', GLOB_ONLYDIR | GLOB_NOSORT);
 }, $braces)));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | 

Use static callback for array_map in `link`
